### PR TITLE
Implement Generic Type For InputField

### DIFF
--- a/apps/client/src/components/Sign/InputField.tsx
+++ b/apps/client/src/components/Sign/InputField.tsx
@@ -1,16 +1,15 @@
-import { UseFormRegister, Path } from "react-hook-form";
-import { SignInFormInput, SignUpFormInput } from "../../types";
+import { UseFormRegister, Path, FieldValues } from "react-hook-form";
 
-type InputField = {
-    type: string, 
+type InputField<T extends FieldValues > = {
+    type: string,
     placeholder: string, 
     header: string, 
-    register: UseFormRegister<SignInFormInput & SignUpFormInput>, 
-    registerData: Path<SignUpFormInput & SignInFormInput>,
+    register: UseFormRegister<T>, 
+    registerData: Path<T>,
     errors: string | undefined
 }
 
-const InputField = ({type, placeholder, header, register, registerData, errors}: InputField): JSX.Element => {
+const InputField = <T extends FieldValues,>({type, placeholder, header, register, registerData, errors}: InputField<T>): JSX.Element => {
     errors = errors ? errors[0].toUpperCase() + errors.slice(1, errors.length) : undefined;
 
     return <div className="text-xl flex flex-col justify-start items-start pt-4 py-4 w-[70%] gap-1">

--- a/apps/client/src/sections/Login/LogInForm.tsx
+++ b/apps/client/src/sections/Login/LogInForm.tsx
@@ -1,6 +1,6 @@
 import { useForm } from "react-hook-form"
 import { InputField, SignTextArea, SignButton } from "../../components/Sign";
-import { SignInFormInput } from "../../types";
+import { SignFormInput } from "../../types";
 import { integrateLogin, handleSignupAndLogin } from "../../utils";
 import { useRecoilState } from "recoil";
 import flashMessageAtom from "../../store/flashMessageAtom";
@@ -8,7 +8,7 @@ import { useNavigate } from "react-router-dom";
 import FlashMessage from "../../components/FlashMessage";
 
 const LogInForm = () => {
-    const { register,handleSubmit, formState: {errors} } = useForm<SignInFormInput>({
+    const { register,handleSubmit, formState: {errors} } = useForm<SignFormInput>({
         defaultValues: {
             email: "",
             password: ""
@@ -25,8 +25,8 @@ const LogInForm = () => {
         <div className="text-6xl tracking-tight font-mono font-medium text-slate-200">Sign In To Patra Account</div>
         <div className="text-3xl flex justify-center pb-6">One Patra account is all you need to manage your cards</div>
         <div className="block h-0.5 w-full bg-sky-200 rounded-xl mb-8"></div>
-        <InputField type={"text"} placeholder={"ashutoshgupta1311@gmail.com"} header={"Email"} register={register} registerData={"email"} errors={errors.email?.message}/>
-        <InputField type={"password"} placeholder={"pass1234"} header={"Password"} register={register} registerData={"password"} errors={errors.password?.message}/>
+        <InputField<SignFormInput> type={"text"} placeholder={"ashutoshgupta1311@gmail.com"} header={"Email"} register={register} registerData={"email"} errors={errors.email?.message}/>
+        <InputField<SignFormInput> type={"password"} placeholder={"pass1234"} header={"Password"} register={register} registerData={"password"} errors={errors.password?.message}/>
         <SignButton buttonContent="Log In" />
         <SignTextArea message="Don't Have Patra Account" link="/signup" anchorElement="Create One" />
     </form>

--- a/apps/client/src/sections/Signup/SignupForm.tsx
+++ b/apps/client/src/sections/Signup/SignupForm.tsx
@@ -1,6 +1,6 @@
 import { useForm } from "react-hook-form"
 import { InputField, SignTextArea, SignButton } from "../../components/Sign";
-import { SignUpFormInput } from "../../types";
+import { SignFormInput } from "../../types";
 import { integrateSignup, handleSignupAndLogin } from "../../utils";
 import FlashMessage from "../../components/FlashMessage";
 import { useRecoilState } from "recoil";
@@ -8,7 +8,7 @@ import flashMessageAtom from "../../store/flashMessageAtom";
 import { useNavigate } from "react-router-dom";
 
 const SignupForm = () => {
-    const { register,handleSubmit, formState: {errors} } = useForm<SignUpFormInput>({
+    const { register,handleSubmit, formState: {errors} } = useForm<SignFormInput>({
         defaultValues: {
             username: "",
             email: "",
@@ -26,9 +26,9 @@ const SignupForm = () => {
         <div className="text-6xl tracking-tight font-mono font-medium text-slate-200">Create Your Patra Account</div>
         <div className="text-3xl flex justify-center pb-6">One Patra account is all you need to manage your cards</div>
         <div className="block h-0.5 w-full bg-sky-200 rounded-xl mb-8"></div>
-        <InputField type={"text"} placeholder={"Starvader"} header={"Username"} register={register} registerData={"username"} errors={errors.username?.message}/>
-        <InputField type={"text"} placeholder={"ashutoshgupta1311@gmail.com"} header={"Email"} register={register} registerData={"email"} errors={errors.email?.message}/>
-        <InputField type={"password"} placeholder={"pass1234"} header={"Password"} register={register} registerData={"password"} errors={errors.password?.message}/>
+        <InputField<SignFormInput> type={"text"} placeholder={"Starvader"} header={"Username"} register={register} registerData={"username"} errors={errors.username?.message}/>
+        <InputField<SignFormInput> type={"text"} placeholder={"ashutoshgupta1311@gmail.com"} header={"Email"} register={register} registerData={"email"} errors={errors.email?.message}/>
+        <InputField<SignFormInput> type={"password"} placeholder={"pass1234"} header={"Password"} register={register} registerData={"password"} errors={errors.password?.message}/>
         <SignButton buttonContent="Sign Up" />
         <SignTextArea message="Already Have Patra Account" link="/login" anchorElement="Log In" />
     </form>

--- a/apps/client/src/types/SIgnUpFormInput.ts
+++ b/apps/client/src/types/SIgnUpFormInput.ts
@@ -1,7 +1,7 @@
-type SignUpFormInput = {
+type SignFormInput = {
     username?: string,
     email: string,
     password: string
 }
 
-export default SignUpFormInput;
+export default SignFormInput;

--- a/apps/client/src/types/index.ts
+++ b/apps/client/src/types/index.ts
@@ -1,9 +1,7 @@
-import SignInFormInput from "./SignInFormInput";
-import SignUpFormInput from "./SIgnUpFormInput";
+import SignFormInput from "./SIgnUpFormInput";
 import IntegrateSignResult from "./IntegrateSignResult";
 
 export type {
-    SignInFormInput,
-    SignUpFormInput,
+    SignFormInput,
     IntegrateSignResult
 }

--- a/apps/client/src/utils/handleSignupAndLogin.ts
+++ b/apps/client/src/utils/handleSignupAndLogin.ts
@@ -1,8 +1,8 @@
 import { NavigateFunction } from "react-router-dom";
 import { SetterOrUpdater } from "recoil";
-import { IntegrateSignResult, SignUpFormInput } from "../types";
+import { IntegrateSignResult, SignFormInput } from "../types";
 
-const handleSignupAndLogin = async (data: SignUpFormInput, integrateFunction: (data: SignUpFormInput) => Promise<IntegrateSignResult>, setFlashMessage: SetterOrUpdater<string> , navigate: NavigateFunction) => {
+const handleSignupAndLogin = async (data: SignFormInput, integrateFunction: (data: SignFormInput) => Promise<IntegrateSignResult>, setFlashMessage: SetterOrUpdater<string> , navigate: NavigateFunction) => {
     const response = await integrateFunction(data);
     setFlashMessage(response.message);
     if(response.token){

--- a/apps/client/src/utils/integrateLogin.ts
+++ b/apps/client/src/utils/integrateLogin.ts
@@ -1,4 +1,4 @@
-import { SignInFormInput, IntegrateSignResult } from "../types";
+import { SignFormInput, IntegrateSignResult } from "../types";
 import zod from 'zod';
 import axios from 'axios'
 
@@ -7,7 +7,7 @@ const loginInputSchema = zod.object({
     password: zod.string({message: "Password is required and should be a valid string"}).min(4, {message: "Password should be minimum of 4 characters"}).max(12, {message: "Password should be maximum of 25 characters"}),
 }).strict();
 
-const integrateLogin = async (data: SignInFormInput) => {
+const integrateLogin = async (data: SignFormInput) => {
     const zodResponse = loginInputSchema.safeParse(data);
 
     if(!zodResponse.success){

--- a/apps/client/src/utils/integrateSignup.ts
+++ b/apps/client/src/utils/integrateSignup.ts
@@ -1,4 +1,4 @@
-import { IntegrateSignResult, SignUpFormInput } from "../types";
+import { IntegrateSignResult, SignFormInput } from "../types";
 import zod from 'zod';
 import axios from "axios";
 
@@ -8,7 +8,7 @@ const signupInputSchema = zod.object({
     password: zod.string({message: "Password is required and should be a valid string"}).min(4, {message: "Password should be minimum of 4 characters"}).max(12, {message: "Password should be maximum of 25 characters"}),
 })
 
-const integrateSignup = async (data: SignUpFormInput) => {
+const integrateSignup = async (data: SignFormInput) => {
     const zodResponse = signupInputSchema.safeParse(data);
 
     if(!zodResponse.success){


### PR DESCRIPTION
This PR aims to close #43 by implementing these changes:

- Refactor the `InputField` to be a Generic Template for different form elements.
- The template utilizes three things:
  - `UseFormRegister`: Type for the `register` function from `react-hook-form`.
  - `Path`: Utility type to get the valid keys of a form object.
  - `FieldValues`: A base type provided by `react-hook-form` that represents form data.
- The Generic Template extends `FieldValues`, ensuring:
  - `T extends FieldValues`: Ensures that `T` must conform to the `FieldValues` type, which means `T` can be any type that has the structure of `FieldValues`.
  - `register: UseFormRegister<T>`: The `register` function must be compatible with the form data type `T`.
  - `registerData: Path<T>`: The `registerData` must be a valid key of the form data type `T`.
